### PR TITLE
Fix crash on latest version of pyrawores

### DIFF
--- a/MomoPyTweak/prototypes/final-fixed-military.lua
+++ b/MomoPyTweak/prototypes/final-fixed-military.lua
@@ -3,9 +3,11 @@ function momoPyTweak.finalFixes.Military()
 	local ITEM = momoIRTweak.FastItem
 
 	local recipe = data.raw.recipe["ammo-initial"]
-	recipe.results = nil
-	recipe.result = "firearm-magazine"
-	recipe.result_count = 5
+	if recipe then
+		recipe.results = nil
+		recipe.result = "firearm-magazine"
+		recipe.result_count = 5
+	end
 	momoIRTweak.recipe.SetResultCount("firearm-magazine", 6)
 	
 	


### PR DESCRIPTION
Fix crash on latest version of  pyrawores, which doen't contain "ammo-initial" recipe anymore.